### PR TITLE
T8531: add Mergify config with commands restrictions

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,0 +1,26 @@
+pull_request_rules:
+  - name: Label conflicting pull requests
+    description: Add a label to a pull request with conflict to spot it easily
+    conditions:
+      - conflict
+      - '-closed'
+    actions:
+      label:
+        toggle:
+          - conflicts
+
+commands_restrictions:
+  backport: &allowed
+    conditions:
+      - or:
+        - sender=@vyos/maintainers
+        - sender=vyosbot
+  copy: *allowed
+  dequeue: *allowed
+  queue: *allowed
+  rebase: *allowed
+  refresh: *allowed
+  requeue: *allowed
+  squash: *allowed
+  unqueue: *allowed
+  update: *allowed

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -22,5 +22,4 @@ commands_restrictions:
   refresh: *allowed
   requeue: *allowed
   squash: *allowed
-  unqueue: *allowed
   update: *allowed


### PR DESCRIPTION
## Summary

Add `.github/mergify.yml` with conflict-label rule and `commands_restrictions` block, restricting the 10 Mergify slash commands (backport, copy, dequeue, queue, rebase, refresh, requeue, squash, unqueue, update) to members of the `@vyos/maintainers` team, plus the `vyosbot` automation account.

## Test plan

- [ ] Non-maintainer comments `@Mergifyio backport sagitta` on a PR → Mergify refuses
- [ ] Maintainer comments the same → backport PR created
- [ ] Conflict-labeling rule fires on conflicting PRs

## References

- Ticket: [T8531](https://vyos.dev/T8531)
- Mergify docs: https://docs.mergify.com/commands/restrictions/

🤖 Generated by [robots](https://vyos.io)