### PR TITLE
general: T8595: add CLAUDE.md

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/.cursorrules
+++ b/.cursorrules
@@ -1,1 +1,0 @@
-CLAUDE.md

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,1 @@
+../CLAUDE.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,54 @@
+# CLAUDE.md
+
+## Project purpose
+
+VyOS fork of `biosdevname` — a Dell-originated utility that maps Linux kernel network-device names (e.g. `eth0`) to BIOS/chassis-supplied names (e.g. `Gb1`). Ships as the `vyatta-biosdevname` Debian package and is invoked by udev rules during interface naming.
+
+## Tech stack
+
+- C, GNU autotools (`configure.ac`, `Makefile.am`, `ltmain.sh`).
+- Debian packaging in `debian/` (debhelper >= 5, `autotools-dev`, `libpci-dev`, `autoconf`, `automake`).
+- License: GPL-2.0 (per `COPYING`).
+
+## Build / test / run
+
+```sh
+autoreconf -fi
+./configure
+make
+dpkg-buildpackage -us -uc
+```
+
+No in-tree test runner.
+
+## Repository layout
+
+- `src/` — main biosdevname source.
+- `biosdevname.1` — man page.
+- `biosdevname.rules.in` — udev rules template.
+- `biosdevname.spec.fedora.in`, `biosdevname.spec.suse.in` — RPM specs (upstream).
+- `debian/`.
+
+## Cross-repo context
+
+Listed in `VyOS-Networks/vyos-build-packages/repos.toml`. Pulled into the ISO via `vyos/vyos-build`. Provides predictable interface naming used throughout `vyos-1x`'s ifconfig logic.
+
+## Conventions
+
+- Default branch `current`.
+- Commit / PR title format: `component: T12345: description` (Phorge task ID at https://vyos.dev).
+- Active workflows: `cla-check.yml`, `trigger-rebuild-repo-package.yml` — wired into the rebuild-dispatch chain, but **not** the PR-mirror pipeline.
+- Treat as upstream-vendored; minimise diffs against the original Dell biosdevname.
+
+## Mirror relationship
+
+Mirror twin: `VyOS-Networks/vyatta-biosdevname`. Canonical side is here. The VyOS-Networks twin's default branch is the experimental `git-actions` (per relations doc §8.2) — ignore for canonical state.
+
+## Notes for future contributors
+
+- Renaming the source/binary package from upstream `biosdevname` to `vyatta-biosdevname` is intentional — don't revert.
+- Any change here can affect interface naming on every VyOS install; coordinate with `vyos-1x` if you change rule names.
+
+---
+
+This file is mirrored on Confluence: [`vyos/vyatta-biosdevname`](https://internal.confluence.vyos.com/wiki/spaces/VYOS/pages/818544818). The Confluence page also carries the per-repo audit data (settings, workflows, secret counts, hygiene) that complements this CLAUDE.md. Edit either side; resync via the documentation pipeline.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,3 @@ Mirror twin: `VyOS-Networks/vyatta-biosdevname`. Canonical side is here. The VyO
 
 - Renaming the source/binary package from upstream `biosdevname` to `vyatta-biosdevname` is intentional — don't revert.
 - Any change here can affect interface naming on every VyOS install; coordinate with `vyos-1x` if you change rule names.
-
----
-
-This file is mirrored on Confluence: [`vyos/vyatta-biosdevname`](https://internal.confluence.vyos.com/wiki/spaces/VYOS/pages/818544818). The Confluence page also carries the per-repo audit data (settings, workflows, secret counts, hygiene) that complements this CLAUDE.md. Edit either side; resync via the documentation pipeline.


### PR DESCRIPTION
## Summary

Adds a single source of truth for repo-level agent instructions, plus three symlinks so different agentic tools all read the same content from one canonical file.

**Files added:**

| Path | Type | Consumed by |
|---|---|---|
| `CLAUDE.md` | real file | Claude Code, Anthropic agents |
| `AGENTS.md` | symlink → `CLAUDE.md` | tools that follow the AGENTS.md convention (e.g. OpenAI Codex) |
| `.cursorrules` | symlink → `CLAUDE.md` | Cursor |
| `.github/copilot-instructions.md` | symlink → `../CLAUDE.md` | GitHub Copilot ([docs](https://docs.github.com/en/copilot/how-tos/configure-custom-instructions-in-your-ide/add-repository-instructions-in-your-ide)) |

**Rationale**

- One source of truth — guidance lives in `CLAUDE.md`, the symlinks are zero-content. No drift between four files.
- Each agentic tool reads its canonical filename and gets the same content.
- Mac/Linux dev environments handle symlinks natively. Windows checkouts may render them as text files containing the target path; the canonical `CLAUDE.md` is unaffected and still rendered/served correctly by GitHub.

**Out of scope**

Path-specific Copilot instructions (`.github/instructions/*.instructions.md`) need YAML frontmatter (`applyTo:`) and target specific globs, so they cannot be symlinks. Not added here; they can be authored as separate small files per-repo if/when narrow path-scoped guidance is needed.

Tracked under [T8595](https://vyos.dev/T8595).

## Test plan

- [ ] `CLAUDE.md` renders on GitHub.
- [ ] `AGENTS.md`, `.cursorrules`, `.github/copilot-instructions.md` resolve to CLAUDE.md content (`readlink` returns the right target).
- [ ] CI passes.

🤖 Generated by [robots](https://vyos.io)
