### PR TITLE
general: T8595: add AGENTS.md

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,1 @@
+../AGENTS.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,50 @@
+# AGENTS.md
+
+## Project purpose
+
+VyOS fork of `biosdevname` — a Dell-originated utility that maps Linux kernel network-device names (e.g. `eth0`) to BIOS/chassis-supplied names (e.g. `Gb1`). Ships as the `vyatta-biosdevname` Debian package and is invoked by udev rules during interface naming.
+
+## Tech stack
+
+- C, GNU autotools (`configure.ac`, `Makefile.am`, `ltmain.sh`).
+- Debian packaging in `debian/` (debhelper >= 5, `autotools-dev`, `libpci-dev`, `autoconf`, `automake`).
+- License: GPL-2.0 (per `COPYING`).
+
+## Build / test / run
+
+```sh
+autoreconf -fi
+./configure
+make
+dpkg-buildpackage -us -uc
+```
+
+No in-tree test runner.
+
+## Repository layout
+
+- `src/` — main biosdevname source.
+- `biosdevname.1` — man page.
+- `biosdevname.rules.in` — udev rules template.
+- `biosdevname.spec.fedora.in`, `biosdevname.spec.suse.in` — RPM specs (upstream).
+- `debian/`.
+
+## Cross-repo context
+
+Listed in `VyOS-Networks/vyos-build-packages/repos.toml`. Pulled into the ISO via `vyos/vyos-build`. Provides predictable interface naming used throughout `vyos-1x`'s ifconfig logic.
+
+## Conventions
+
+- Default branch `current`.
+- Commit / PR title format: `component: T12345: description` (Phorge task ID at https://vyos.dev).
+- Active workflows: `cla-check.yml`, `trigger-rebuild-repo-package.yml` — wired into the rebuild-dispatch chain, but **not** the PR-mirror pipeline.
+- Treat as upstream-vendored; minimise diffs against the original Dell biosdevname.
+
+## Mirror relationship
+
+Mirror twin: `VyOS-Networks/vyatta-biosdevname`. Canonical side is here. The VyOS-Networks twin's default branch is the experimental `git-actions` (per relations doc §8.2) — ignore for canonical state.
+
+## Notes for future contributors
+
+- Renaming the source/binary package from upstream `biosdevname` to `vyatta-biosdevname` is intentional — don't revert.
+- Any change here can affect interface naming on every VyOS install; coordinate with `vyos-1x` if you change rule names.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,7 @@ No in-tree test runner.
 
 ## Cross-repo context
 
-Listed in `VyOS-Networks/vyos-build-packages/repos.toml`. Pulled into the ISO via `vyos/vyos-build`. Provides predictable interface naming used throughout `vyos-1x`'s ifconfig logic.
+Listed in an internal repository. Pulled into the ISO via `vyos/vyos-build`. Provides predictable interface naming used throughout `vyos-1x`'s ifconfig logic.
 
 ## Conventions
 
@@ -39,10 +39,6 @@ Listed in `VyOS-Networks/vyos-build-packages/repos.toml`. Pulled into the ISO vi
 - Commit / PR title format: `component: T12345: description` (Phorge task ID at https://vyos.dev).
 - Active workflows: `cla-check.yml`, `trigger-rebuild-repo-package.yml` — wired into the rebuild-dispatch chain, but **not** the PR-mirror pipeline.
 - Treat as upstream-vendored; minimise diffs against the original Dell biosdevname.
-
-## Mirror relationship
-
-Mirror twin: `VyOS-Networks/vyatta-biosdevname`. Canonical side is here. The VyOS-Networks twin's default branch is the experimental `git-actions` (per the cross-repo audit) — ignore for canonical state.
 
 ## Notes for future contributors
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,7 @@ Listed in `VyOS-Networks/vyos-build-packages/repos.toml`. Pulled into the ISO vi
 
 ## Mirror relationship
 
-Mirror twin: `VyOS-Networks/vyatta-biosdevname`. Canonical side is here. The VyOS-Networks twin's default branch is the experimental `git-actions` (per relations doc §8.2) — ignore for canonical state.
+Mirror twin: `VyOS-Networks/vyatta-biosdevname`. Canonical side is here. The VyOS-Networks twin's default branch is the experimental `git-actions` (per the cross-repo audit) — ignore for canonical state.
 
 ## Notes for future contributors
 


### PR DESCRIPTION
Adds `AGENTS.md` (tool-neutral primary instructions) at repo root and a symlink `.github/copilot-instructions.md` → `../AGENTS.md` for Copilot code review compatibility.

Schema rationale and full spec: [T8595](https://vyos.dev/T8595).

**Why this shape:** Cursor 0.50+, Claude Code, OpenAI Codex, and Copilot Coding Agent / Chat / CLI read `AGENTS.md` natively. Copilot **code review** is the single tool that doesn't (per [GitHub's docs](https://docs.github.com/en/copilot/reference/custom-instructions-support)) — the symlink is the workaround until [community/discussions/174058](https://github.com/orgs/community/discussions/174058) lands. Replaces the previous `CLAUDE.md`-only schema PR for this repo.
