### PR TITLE
chore: T8943: migrate mirror wrapper to canonical uniform stub (R2 Task 6)

### DIFF
--- a/.github/workflows/pr-mirror-repo-sync.yml
+++ b/.github/workflows/pr-mirror-repo-sync.yml
@@ -6,7 +6,7 @@ name: PR Mirror and Repo Sync
 on:
   pull_request_target:
     types: [closed]
-    branches: [rolling]
+    branches: [rolling, production]
   workflow_dispatch:
     inputs:
       sync_branch:
@@ -14,16 +14,13 @@ on:
         type: string
 
 permissions:
-  contents: write
-  pull-requests: write
-  issues: write
+  contents: read
 
 jobs:
   call:
     if: |
       github.repository_owner == 'vyos'
       && (github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch')
-      && vars.MIRROR_ENABLED != 'false'
     uses: vyos/.github/.github/workflows/pr-mirror-repo-sync.yml@production
     with:
       sync_branch: ${{ inputs.sync_branch || github.event.pull_request.base.ref }}


### PR DESCRIPTION
Rollout 2 Task 6 pilot. Migrates the mirror wrapper to the spec §4.2.3 canonical stub (contents:read, branches:[rolling,production], central kill-switch). Mechanism proven by vyos/ipaddrcheck#35; this is the first post-reconciliation migration. Tracking: T8943 / IS-432.